### PR TITLE
[WED-38] Install Bootstrap, Slim, and Slim template generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,11 @@ gem 'dotenv-rails', '>= 2.0.1'
 # https://github.com/state-machines/state_machines-activerecord
 gem 'state_machines-activerecord'
 
+# Use Bootstrap as the application's front-end framework
+gem 'bootstrap-sass', '~> 3.3.6'
+# Use Slim template
+gem 'slim-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,8 +37,13 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.3)
+    autoprefixer-rails (6.3.3.1)
+      execjs
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bootstrap-sass (3.3.6)
+      autoprefixer-rails (>= 5.2.1)
+      sass (>= 3.3.4)
     builder (3.2.2)
     byebug (8.2.2)
     coffee-rails (4.1.1)
@@ -143,6 +148,15 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    slim (3.0.6)
+      temple (~> 0.7.3)
+      tilt (>= 1.3.3, < 2.1)
+    slim-rails (3.0.1)
+      actionmailer (>= 3.1, < 5.0)
+      actionpack (>= 3.1, < 5.0)
+      activesupport (>= 3.1, < 5.0)
+      railties (>= 3.1, < 5.0)
+      slim (~> 3.0)
     spring (1.6.3)
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
@@ -158,6 +172,7 @@ GEM
     state_machines-activerecord (0.3.0)
       activerecord (~> 4.1)
       state_machines-activemodel (>= 0.3.0)
+    temple (0.7.6)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
@@ -178,6 +193,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bootstrap-sass (~> 3.3.6)
   byebug
   coffee-rails (~> 4.1.0)
   dotenv-rails (>= 2.0.1)
@@ -190,6 +206,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  slim-rails
   spring
   state_machines-activerecord
   turbolinks

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,3 +14,5 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .
+//= require bootstrap
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,6 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
- *= require_tree .
- *= require_self
  */
+@import "bootstrap-sprockets";
+@import "bootstrap";

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,4 +76,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Minify CSS
+  config.sass.style = :compressed
 end


### PR DESCRIPTION
This installs 3 gems:
* Bootstrap (front-end framework)
* Slim (template language)
* Slim template (template generator so that view files are auto-generated when controller, etc are generated)

#### Notable changes
Renamed `application.css` to `application.scss` and removed `*= require_tree .` and `*= require_self` as per the gem's docs