### PR TITLE
Add phone number to Donors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,10 @@ gem 'kaminari'
 # Decorators
 gem 'draper'
 
+# validations - phone number
+gem 'phonelib'
+
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,7 @@ GEM
       mini_portile2 (~> 2.0.0.rc2)
     orm_adapter (0.5.0)
     pg (0.18.3)
+    phonelib (0.6.0)
     polyamorous (1.3.0)
       activerecord (>= 3.0)
     rack (1.6.4)
@@ -342,6 +343,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   pg
+  phonelib
   rails (= 4.2.5)
   rspec-rails
   sass-rails (~> 5.0)

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -19,6 +19,7 @@ ActiveAdmin.register User do
     # View, edit, delete, depending on which actions are enabled
     actions
     column :email
+    column :phone_number
     column :name
     column :role_type
     column :created_at
@@ -36,6 +37,7 @@ ActiveAdmin.register User do
     attributes_table do
       row :name
       row :email
+      row :phone_number
       row :role_type
       row :created_at
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,14 @@ class User < ActiveRecord::Base
     RegistrationMailer.registration_email(self).deliver_now
   end
 
+
+  validate :validate_donor_fields
+
+  def validate_donor_fields
+    if role_type == 'Donor'
+      unless Phonelib.valid_for_country?(phone_number, 'US') || Phonelib.possible?(phone_number)
+        errors.add(:phone_number, 'must be valid')
+      end
+    end
+  end
 end

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -13,6 +13,9 @@ div.wishlist-page
       = f.label :email, "Email Address"
       = f.email_field :email, class: 'form-control'
 
+    div.form-group
+      = f.label :phone_number, "Phone Number"
+      = f.telephone_field :phone_number, class: 'form-control'
 
     div.form-group
       = f.label "Role"

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -5,13 +5,16 @@ div.wishlist-page
       .alert.alert-danger role="alert"
         span.glyphicon.glyphicon-exclamation-sign aria-hidden="true"
         span.sr-only Error:
-        = render partial: 'modules/error', locals: {errors: @gift_request.errors.full_messages}
+        = render partial: 'modules/error', locals: {errors: resource.errors.full_messages}
     div.form-group
       = f.label :name
       = f.text_field :name, autofocus: true, class: 'form-control'
     div.form-group
       = f.label :email, "Enter your email address"
       = f.email_field :email, class: 'form-control', placeholder: 'example@mail.com'
+    div.form-group
+      = f.label :phone_number, "Enter your phone number"
+      = f.telephone_field :phone_number, class: 'form-control', placeholder: '555-867-5309'
 
     div.form-group
       = f.label :password, "Create a password"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -281,10 +281,10 @@ Devise::RegistrationsController.class_eval do
   end
 
   def sign_up_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation, :role_type)
+    params.require(:user).permit(:name, :email, :phone_number, :password, :password_confirmation, :role_type)
   end
 
   def account_update_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation, :role_type, :current_password)
+    params.require(:user).permit(:name, :email, :phone_number, :password, :password_confirmation, :role_type, :current_password)
   end
 end

--- a/db/migrate/20160421192814_add_phone_number_to_user.rb
+++ b/db/migrate/20160421192814_add_phone_number_to_user.rb
@@ -1,0 +1,5 @@
+class AddPhoneNumberToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :phone_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160420205814) do
+ActiveRecord::Schema.define(version: 20160421192814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 20160420205814) do
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
+    t.string   "phone_number"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     name "Decker"
     password "buttscarlton"
     password_confirmation "buttscarlton"
+    phone_number '617-111-1111'
 
     factory :therapist_user, class: "User" do
       association :role, factory: :therapist


### PR DESCRIPTION
Just adds phone number field to user model. Makes sure phone numbers are potentially valid for donors. (doesn't care if phone numbers are active, doesn't care about phone numbers for therapists/admins [but will ask for the field on signup])